### PR TITLE
Add Retry + delay on HTTP 429

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -7,11 +7,34 @@ import { type Article, type RemoteArticleData, type ArticleStats } from './model
 const debug = Debug('devto');
 const apiUrl = 'https://dev.to/api';
 const paginationLimit = 1000;
+const maxRetries = 3;
+const retryDelay = 1000; // 1 second delay before retrying
 
 // There's a limit of 10 articles created each 30 seconds by the same user,
 // so we need to throttle the API calls in that case.
 // The insane type casting is due to typing issues with p-throttle.
 const throttledPostForCreate = pThrottle({ limit: 10, interval: 30_500 })(got.post) as any as Got['post'];
+
+// There's a limit of 30 requests each 30 seconds by the same user, so we need to throttle the API calls in that case too.
+const throttledPutForUpdate = pThrottle({ limit: 30, interval: 30_500 })(
+  async (url: string, options: any) => got.put(url, options)
+) as any as Got['put'];
+
+async function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function retryRequest(fn: () => Promise<RemoteArticleData>, retries: number): Promise<RemoteArticleData> {
+  try {
+    return await fn();
+  } catch (error) {
+    if (retries === 0 || !(error instanceof RequestError && error.response?.statusCode === 429)) {
+      throw error;
+    }
+    await delay(retryDelay);
+    return retryRequest(fn, retries - 1);
+  }
+}
 
 export async function getAllArticles(devtoKey: string): Promise<RemoteArticleData[]> {
   try {
@@ -69,22 +92,26 @@ export async function getLastArticlesStats(devtoKey: string, number: number): Pr
 }
 
 export async function updateRemoteArticle(article: Article, devtoKey: string): Promise<RemoteArticleData> {
-  try {
-    const markdown = matter.stringify(article, article.data, { lineWidth: -1 } as any);
-    const { id } = article.data;
-    // Throttle API calls in case of article creation
-    const get = id ? got.put : throttledPostForCreate;
-    const result = await get(`${apiUrl}/articles${id ? `/${id}` : ''}`, {
-      headers: { 'api-key': devtoKey },
-      json: { article: { title: article.data.title, body_markdown: markdown } },
-      responseType: 'json'
-    });
-    return result.body as RemoteArticleData;
-  } catch (error) {
-    if (error instanceof RequestError && error.response) {
-      debug('Debug infos: %O', error.response.body);
-    }
+  const update = async (): Promise<RemoteArticleData> => {
+    try {
+      const markdown = matter.stringify(article, article.data, { lineWidth: -1 } as any);
+      const { id } = article.data;
+      // Throttle API calls in case of article creation
+      const get = id ? throttledPutForUpdate : throttledPostForCreate;
+      const result = await get(`${apiUrl}/articles${id ? `/${id}` : ''}`, {
+        headers: { 'api-key': devtoKey },
+        json: { article: { title: article.data.title, body_markdown: markdown } },
+        responseType: 'json'
+      });
+      return result.body as RemoteArticleData;
+    } catch (error) {
+      if (error instanceof RequestError && error.response) {
+        debug('Debug infos: %O', error.response.body);
+      }
 
-    throw error;
-  }
+      throw error;
+    }
+  };
+
+  return retryRequest(update, maxRetries);
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -31,6 +31,7 @@ async function retryRequest(fn: () => Promise<RemoteArticleData>, retries: numbe
     if (retries === 0 || !(error instanceof RequestError && error.response?.statusCode === 429)) {
       throw error;
     }
+    debug('Rate limited, retrying in %s ms', retryDelay);
     await delay(retryDelay);
     return retryRequest(fn, retries - 1);
   }
@@ -96,7 +97,7 @@ export async function updateRemoteArticle(article: Article, devtoKey: string): P
     try {
       const markdown = matter.stringify(article, article.data, { lineWidth: -1 } as any);
       const { id } = article.data;
-      // Throttle API calls in case of article creation
+      // Throttle API calls in case of article creation or update
       const get = id ? throttledPutForUpdate : throttledPostForCreate;
       const result = await get(`${apiUrl}/articles${id ? `/${id}` : ''}`, {
         headers: { 'api-key': devtoKey },


### PR DESCRIPTION
Hi, as discussed at issue https://github.com/sinedied/publish-devto/issues/37 I've implemented a Retry + delay for update/create articles here. 

As the code already has `pThrottle`, I reused it too to limit the number of requests to 30 every 30 seconds as said on `dev.to` docs.

Now the code uses `pThrottle` both to Create and to Update the Article and if the request fails a retry with a max quantity of 3 retries each 1 second of delay is applied.

Could you please review @sinedied? If needed, mention the issue here about 429 too.